### PR TITLE
Removes console.log call

### DIFF
--- a/extension/content.ts
+++ b/extension/content.ts
@@ -108,8 +108,6 @@ function init() {
         setInterval(updateTwitterClasses, 800);
     }
 
-    console.log('Self: ' + myself)
-
     document.addEventListener('contextmenu', evt => {
         lastRightClickedElement = <HTMLElement>evt.target;
     }, true);


### PR DESCRIPTION
This removes the log call of `'Self:'  + myself`.
The log call seemingly serves no purpose, and looks like it's leftover from debugging.
It pollutes the console, and adds noise you don't want when actively using the console when developing web apps.