### PR TITLE
Add support for Goodreads Authors when viewing book pages

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -461,6 +461,8 @@ const socialNetworkPatterns = [
             "*://*.google.com/*",
             "*://*.bing.com/*",
             "*://duckduckgo.com/*",
+            "*://*.amazon.com/*",
+            "*://*.goodreads.com/*",
 ];
 
 const homepagePatterns = [

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -461,7 +461,6 @@ const socialNetworkPatterns = [
             "*://*.google.com/*",
             "*://*.bing.com/*",
             "*://duckduckgo.com/*",
-            "*://*.amazon.com/*",
             "*://*.goodreads.com/*",
 ];
 

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -31,7 +31,7 @@ function fixupSiteStyles() {
             .assigned-label-transphobic { outline: 2px solid var(--ShinigamiEyesTransphobic) !important; }
             .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
         `);
-    } else if (hostname == 'rationalwiki.org' || domainIs(hostname, 'wikipedia.org') || hostname == 'amazon.com' || hostname == 'goodreads.com') {
+    } else if (hostname == 'rationalwiki.org' || domainIs(hostname, 'wikipedia.org') || hostname == 'goodreads.com') {
         addStyleSheet(`
             .assigned-label-transphobic { outline: 1px solid var(--ShinigamiEyesTransphobic) !important; }
             .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
@@ -94,7 +94,6 @@ function init() {
         'duckduckgo.com',
         'bing.com',
         'goodreads.com',
-        'amazon.com',
     ].includes(hostname) ||
         domainIs(hostname, 'tumblr.com') ||
         domainIs(hostname, 'wikipedia.org') ||
@@ -434,10 +433,7 @@ function getIdentifierFromElementImpl(element: HTMLAnchorElement, originalTarget
         if (element.classList.contains('authorName')) return element.textContent;
         if (element.classList.contains('author')) return element.textContent;
         if (element.classList.contains('gr-book__authorLink')) return element.textContent;
-    } else if (hostname == 'amazon.com') {
-        if (element.classList.contains('contributorNameID')) return element.textContent;
-        if (element.classList.contains('._cDEzb_p13n-sc-css-line-clamp-1_2o7X6')) return element.textContent;
-    }
+    } 
 
     if (element.classList.contains('tumblelog')) return element.textContent.replace('@', '') + '.tumblr.com';
 

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -93,6 +93,8 @@ function init() {
         'rationalwiki.org',
         'duckduckgo.com',
         'bing.com',
+        'goodreads.com',
+        'amazon.com',
     ].includes(hostname) ||
         domainIs(hostname, 'tumblr.com') ||
         domainIs(hostname, 'wikipedia.org') ||

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -31,7 +31,7 @@ function fixupSiteStyles() {
             .assigned-label-transphobic { outline: 2px solid var(--ShinigamiEyesTransphobic) !important; }
             .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
         `);
-    } else if (hostname == 'rationalwiki.org' || domainIs(hostname, 'wikipedia.org')) {
+    } else if (hostname == 'rationalwiki.org' || domainIs(hostname, 'wikipedia.org') || hostname == 'amazon.com' || hostname == 'goodreads.com') {
         addStyleSheet(`
             .assigned-label-transphobic { outline: 1px solid var(--ShinigamiEyesTransphobic) !important; }
             .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
@@ -430,9 +430,18 @@ function getIdentifierFromElementImpl(element: HTMLAnchorElement, originalTarget
         }
     } else if (domainIs(hostname, 'wikipedia.org')) {
         if (element.classList.contains('interlanguage-link-target')) return null;
+    } else if (hostname == 'goodreads.com') {
+        if (element.classList.contains('authorName')) return element.textContent;
+        if (element.classList.contains('author')) return element.textContent;
+        if (element.classList.contains('gr-book__authorLink')) return element.textContent;
+    } else if (hostname == 'amazon.com') {
+        if (element.classList.contains('contributorNameID')) return element.textContent;
+        if (element.classList.contains('._cDEzb_p13n-sc-css-line-clamp-1_2o7X6')) return element.textContent;
     }
 
     if (element.classList.contains('tumblelog')) return element.textContent.replace('@', '') + '.tumblr.com';
+
+
 
     const href = element.href;
     if (href && (!href.endsWith('#') || href.includes('&stick='))) return getIdentifierFromURLImpl(tryParseURL(href));

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -44,8 +44,7 @@
                 "*://*.google.no/*",
                 "*://*.google.pt/*",
                 "*://*.google.se/*",
-                "*://*.goodreads.com/*",
-                "*://*.amazon.com/*"
+                "*://*.goodreads.com/*"
             ],
             "css": [
                 "content.css"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -43,7 +43,9 @@
                 "*://*.google.it/*",
                 "*://*.google.no/*",
                 "*://*.google.pt/*",
-                "*://*.google.se/*"
+                "*://*.google.se/*",
+                "*://*.goodreads.com/*",
+                "*://*.amazon.com/*"
             ],
             "css": [
                 "content.css"

--- a/extension/options.html
+++ b/extension/options.html
@@ -67,7 +67,7 @@
                     DuckDuckGo <i>(search results)</i></label>
                 <label class="website-checkbox"><input type="checkbox" data-site="tumblr.com">Tumblr</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="twitter.com">Twitter</label>
-                <label class="website-checkbox"><input type="checkbox" data-site="goodreads.com">Goodreads</label>
+                <label class="website-checkbox"><input type="checkbox" data-site="goodreads.com">Goodreads authors</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="wikipedia.org">Wikipedia
                     <i>(topics)</i></label>
                 <label class="website-checkbox"><input type="checkbox" data-site="youtube.com">YouTube</label>

--- a/extension/options.html
+++ b/extension/options.html
@@ -68,7 +68,6 @@
                 <label class="website-checkbox"><input type="checkbox" data-site="tumblr.com">Tumblr</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="twitter.com">Twitter</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="goodreads.com">Goodreads</label>
-                <label class="website-checkbox"><input type="checkbox" data-site="amazon.com">Amazon</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="wikipedia.org">Wikipedia
                     <i>(topics)</i></label>
                 <label class="website-checkbox"><input type="checkbox" data-site="youtube.com">YouTube</label>

--- a/extension/options.html
+++ b/extension/options.html
@@ -67,6 +67,8 @@
                     DuckDuckGo <i>(search results)</i></label>
                 <label class="website-checkbox"><input type="checkbox" data-site="tumblr.com">Tumblr</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="twitter.com">Twitter</label>
+                <label class="website-checkbox"><input type="checkbox" data-site="goodreads.com">Goodreads</label>
+                <label class="website-checkbox"><input type="checkbox" data-site="amazon.com">Amazon</label>
                 <label class="website-checkbox"><input type="checkbox" data-site="wikipedia.org">Wikipedia
                     <i>(topics)</i></label>
                 <label class="website-checkbox"><input type="checkbox" data-site="youtube.com">YouTube</label>


### PR DESCRIPTION
With the current rise of people publishing reactionary transphobic books and the current rise in white nationalist publishing, I thought it was worth adding support for flagging Goodreads authors on individual book pages. A lot of books written by white nationalists and reactionary transphobes have publisher descriptions that deliberately don't make it clear that the book's content is extremist or anti-trans, and because of that, I wanted a way to flag authors so that I can avoid inadvertently adding extremist or reactionary transphobe books to my to-read list.