### PR TITLE
Use HTMLElement.style.cssText for styling

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -18,10 +18,6 @@ body {
    --ShinigamiEyesTransphobic: #FB6A4A;
 }
 
-.assigned-label-transphobic, a.assigned-label-transphobic { color: var(--ShinigamiEyesTransphobic) !important; }
-.assigned-label-t-friendly, a.assigned-label-t-friendly { color: var(--ShinigamiEyesTFriendly) !important; }
-
-.has-assigned-label * { color: inherit !important; }
 .shinigami-eyes-debug-snippet-highlight {
      outline: 2px dashed darkorchid !important;
      background-color: darkorchid !important;

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -11,6 +11,10 @@ if (hostname.endsWith('.youtube.com')) hostname = 'youtube.com';
 
 var myself: string = null;
 var isSocialNetwork: boolean = null;
+var styleMap: {transphobic: string, tFriendly: string} = {
+    transphobic: 'color: var(--ShinigamiEyesTransphobic) !important;', 
+    tFriendly: 'var(--ShinigamiEyesTFriendly) !important;'
+};
 
 function fixupSiteStyles() {
     if (hostname == 'facebook.com') {
@@ -27,22 +31,18 @@ function fixupSiteStyles() {
             {color:inherit;}
         `);
     } else if (domainIs(hostname, 'tumblr.com')) {
-        addStyleSheet(`
-            .assigned-label-transphobic { outline: 2px solid var(--ShinigamiEyesTransphobic) !important; }
-            .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
-        `);
+        styleMap.transphobic = 'outline: 2px solid var(--ShinigamiEyesTransphobic) !important;';
+        styleMap.tFriendly = 'outline: 1px solid var(--ShinigamiEyesTFriendly) !important;';
     } else if (hostname == 'rationalwiki.org' || domainIs(hostname, 'wikipedia.org')) {
-        addStyleSheet(`
-            .assigned-label-transphobic { outline: 1px solid var(--ShinigamiEyesTransphobic) !important; }
-            .assigned-label-t-friendly { outline: 1px solid var(--ShinigamiEyesTFriendly) !important; }
-        `);
+        styleMap.transphobic = 'outline: 1px solid var(--ShinigamiEyesTransphobic) !important;';
+        styleMap.tFriendly = 'outline: 1px solid var(--ShinigamiEyesTFriendly) !important;';
     } else if (hostname == 'twitter.com') {
         myself = getIdentifier(<HTMLAnchorElement>document.querySelector('.DashUserDropdown-userInfo a'));
         addStyleSheet(`
             .pretty-link b, .pretty-link s {
                 color: inherit !important;
             }
-            
+
             a.show-thread-link, a.ThreadedConversation-moreRepliesLink {
                 color: inherit !important;
             }
@@ -154,9 +154,9 @@ function updateTwitterClasses() {
         lastAppliedTwitterUrl = location.href;
     }
     for (const a of document.querySelectorAll('a')) {
-        if (a.assignedCssLabel && !a.classList.contains('has-assigned-label')) {
-            a.classList.add('assigned-label-' + a.assignedCssLabel);
-            a.classList.add('has-assigned-label');
+        if (a.assignedCssLabel && !a.hasAssigned) {
+            a.style.cssText = styleMap[a.assignedCssLabel == 't-friendly' ? 'tFriendly': 'transphobic'];
+            a.hasAssigned = true;
         }
     }
 }
@@ -229,15 +229,15 @@ function solvePendingLabels() {
 
 function applyLabel(a: HTMLAnchorElement, identifier: string) {
     if (a.assignedCssLabel) {
-        a.classList.remove('assigned-label-' + a.assignedCssLabel);
-        a.classList.remove('has-assigned-label');
+        a.style.cssText.replace(styleMap[a.assignedCssLabel == 't-friendly' ? 'tFriendly': 'transphobic'], "");
+        a.hasAssigned = false;
     }
 
     a.assignedCssLabel = knownLabels[identifier] || '';
 
     if (a.assignedCssLabel) {
-        a.classList.add('assigned-label-' + a.assignedCssLabel);
-        a.classList.add('has-assigned-label');
+        a.style.cssText = styleMap[a.assignedCssLabel == 't-friendly' ? 'tFriendly': 'transphobic'];
+        a.hasAssigned = true;
         if (hostname == 'twitter.com')
             a.classList.remove('u-textInheritColor');
     }

--- a/extension/definitions.d.ts
+++ b/extension/definitions.d.ts
@@ -5,6 +5,7 @@ declare class BloomFilter {
 }
 interface HTMLElement {
     assignedCssLabel?: string
+    hasAssigned?: boolean
 }
 interface LabelToSolve {
     element: HTMLAnchorElement

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,6 @@
                 "*://*.twitter.com/*",
                 "*://*.medium.com/*",
                 "*://disqus.com/*",
-                "*://*.tumblr.com/*",
                 "*://*.wikipedia.org/*",
                 "*://*.rationalwiki.org/*",
                 "*://shinigami-eyes.localhost/*",
@@ -54,8 +53,23 @@
             "matches": [
                 "*://*/*"
             ],
+            "exlcude_matches": [
+                "*://*.tumblr.com/*"
+            ],
             "js": [
                 "content.js"
+            ]
+        },
+        {
+            "all_frames": false,
+            "matches": [
+                "*://*.tumblr.com/*"
+            ],
+            "js": [
+                "content.js"
+            ],
+            "css": [
+                "content.css"
             ]
         }
     ],


### PR DESCRIPTION
If we don't modify the classList people can't tell that we didn't modify the classList. Fixes #81 as it is written.

However, I would argue that #81 is a fool's errand of an issue, and has no true fixes. This extension is explicitly meant to modify the DOM. We are adding styling to elements that the style sheets of the website do not have functionality for. There is no way to fully hide these modifications from any other JavaScript that has access to the same DOM. The changes can be obfuscated, but the extension is (purportedly) open source, and anyone attempting to fingerprint users could trivially reverse engineer the obfuscation. 

If you're scared of someone fingerprinting your use of the extension, consider uninstalling the extension? Or disabling JS?