### PR TITLE
Add Transformers forum TFW2005

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -70,7 +70,7 @@
                 "*://lgbtqia.space/*",
                 
                 "*://*.threads.net/*",
-
+                "*://www.tfw2005.com/boards/members/*",
                 
 
                 "*://duckduckgo.com/*",


### PR DESCRIPTION
Sorry if this is way too specific for the extension, but I'd thought it'd be helpful to add TFW2005, a popular Transformers forum, due to its moderations' spotty history when it comes to transmisia, especially when it comes to recent events.
Because this isn't a traditional social media site and instead a Xenforo forum, /boards/members/ is added before. This should allow for members to be selected as anti-Trans or pro-Trans.